### PR TITLE
feat: show/hide posts based on toggle store value

### DIFF
--- a/src/lib/components/ui/navbar.svelte
+++ b/src/lib/components/ui/navbar.svelte
@@ -6,15 +6,15 @@
     import { RefreshCw } from 'lucide-svelte';
     import { Eye } from 'lucide-svelte';
     import { EyeClosed } from 'lucide-svelte';
+    import { isBlueskyToggled } from '../../../stores/blueskyToggle';
+    import { isMastodonToggled } from '../../../stores/mastodonToggle';
 
-    let isMastodonToggled = false;
     function toggleMastodon() {
-        isMastodonToggled = !isMastodonToggled;
+        isMastodonToggled.update(n => !n)
     }
 
-    let isBlueskyToggled = false;
     function toggleBluesky() {
-        isBlueskyToggled = !isBlueskyToggled;
+        isBlueskyToggled.update(n => !n)
     }
 
     export let userInfo: object = {};
@@ -69,7 +69,7 @@
                         
                         <!-- Mastodon -->
                         {#if userInfo.mastodonHandle}
-                            <div class={`${isMastodonToggled ? 'opacity-50' : 'opacity-100'} flex flex-row w-full h-full content-center bg-transparent border-2 border-mastodon rounded-md text-mastodon py-6 px-2`}>
+                            <div class={`${!$isMastodonToggled ? 'opacity-50' : 'opacity-100'} flex flex-row w-full h-full content-center bg-transparent border-2 border-mastodon rounded-md text-mastodon py-6 px-2`}>
                                     <div class="flex flex-col ml-2 mr-4">
                                         <img src={userInfo.mastodonPicture} alt="Mastodon Account" class="w-10 h-10 rounded-full"/>
                                     </div>
@@ -79,7 +79,7 @@
                                     </div>
                                     <div class="flex flex-col mr-0 ml-auto mt-auto mb-auto bg-transparent text-mastodon">
                                         <Toggle aria-label="toggle visible" on:click={toggleMastodon} class="data-[state=on]:bg-transparent data-[state=on]:text-mastodon hover:bg-transparent hover:text-mastodon">
-                                            {#if isMastodonToggled}
+                                            {#if !$isMastodonToggled}
                                                 <EyeClosed class="h-6 w-6" />
                                             {:else}
                                                 <Eye class="h-6 w-6" />
@@ -95,7 +95,7 @@
 
                         <!-- Bluesky -->
                         {#if userInfo.bskyHandle}
-                            <div class={`${isBlueskyToggled ? 'opacity-50' : 'opacity-100'} flex flex-row w-full h-full content-center bg-transparent border-2 border-bluesky rounded-md text-bluesky py-6 px-2`}>
+                            <div class={`${!$isBlueskyToggled ? 'opacity-50' : 'opacity-100'} flex flex-row w-full h-full content-center bg-transparent border-2 border-bluesky rounded-md text-bluesky py-6 px-2`}>
                                     <div class="flex flex-col ml-2 mr-4">
                                         <img src={userInfo.bskyPicture} alt="Bluesky Account" class="w-10 h-10 rounded-full"/>
                                     </div>
@@ -105,7 +105,7 @@
                                     </div>
                                     <div class="flex flex-col mr-0 ml-auto mt-auto mb-auto bg-transparent text-bluesky">
                                         <Toggle aria-label="toggle visible" on:click={toggleBluesky} class="data-[state=on]:bg-transparent data-[state=on]:text-bluesky hover:bg-transparent hover:text-bluesky">
-                                            {#if isBlueskyToggled}
+                                            {#if !($isBlueskyToggled)}
                                                 <EyeClosed class="h-6 w-6" />
                                             {:else}
                                                 <Eye class="h-6 w-6" />

--- a/src/routes/timeline/+layout.svelte
+++ b/src/routes/timeline/+layout.svelte
@@ -25,6 +25,14 @@
         await timelineData.set(await refreshTimeline(data.mastodonToken, data.mastodonInstance, data.bskyToken))
         refreshing.set(false)
     }
+
+    // const toggleMastodon = () => {
+    //     isMastodonToggled = !isMastodonToggled;
+    // }
+
+    // const toggleBluesky = () => {
+    //     isBlueskyToggled = !isBlueskyToggled;
+    // }
 </script>
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/routes/timeline/+page.svelte
+++ b/src/routes/timeline/+page.svelte
@@ -5,6 +5,9 @@
     import { Frown, RefreshCcw } from 'lucide-svelte';
     import { timelineData, refreshing } from "./timelineData";
     export let data
+    import { isBlueskyToggled } from '../../stores/blueskyToggle'
+    import { isMastodonToggled } from "../../stores/mastodonToggle";
+
     timelineData.set(data.timelineData)
 </script>
 
@@ -23,9 +26,22 @@
                 <span class="w-48 mb-2 text-center block">No posts found. Try the refresh button!</span>
             </div>
         {:else}
-            {#each $timelineData.timeline as post}
-                <Post post={post} />
-            {/each}
+            {#if !($isBlueskyToggled) && !($isMastodonToggled)}
+                <Frown class="w-40 h-40 mb-4 opacity-10" />
+                <span class="w-48 mb-2 text-center block">Posts hidden. Toggle the filters to show posts!</span>
+            {:else if !($isBlueskyToggled) && $isMastodonToggled}
+                {#each $timelineData.mastodonTimeline as post}
+                    <Post post={post} />
+                {/each}
+            {:else if $isBlueskyToggled && !($isMastodonToggled)}
+                {#each $timelineData.bskyTimeline as post}
+                    <Post post={post} />
+                {/each}
+            {:else}
+                {#each $timelineData.timeline as post}
+                    <Post post={post} />
+                {/each}
+            {/if}
         {/if}
     {:else}
         <div class="flex flex-col items-center justify-center w-full h-screen">

--- a/src/stores/blueskyToggle.js
+++ b/src/stores/blueskyToggle.js
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const isBlueskyToggled = writable(false);

--- a/src/stores/mastodonToggle.js
+++ b/src/stores/mastodonToggle.js
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const isMastodonToggled = writable(false);


### PR DESCRIPTION
- converted isMastodonToggled and isBlueskyToggled into stores for access and reactivity across pages
- updated the timeline data shown according to store values
- fixed the toggle boolean assignment (it was reversed)