### PR TITLE
UI tweaks for dynamic resizing

### DIFF
--- a/src/lib/components/ui/navbar.svelte
+++ b/src/lib/components/ui/navbar.svelte
@@ -36,9 +36,9 @@
                 <!-- User Details -->
                 <div class="flex flex-col mb-2">
                     <Avatar.Root class="mb-2">
-                        <Avatar.Fallback class="w-10 h-10 bg-kaleido text-white border-2 border-transparent">RF</Avatar.Fallback>
+                        <Avatar.Fallback class="w-10 h-10 bg-kaleido text-white border-2 border-transparent align-left">RF</Avatar.Fallback>
                     </Avatar.Root>
-                    <Sheet.Header class="font-medium">
+                    <Sheet.Header class="font-medium text-left">
                         Rom Feria
                     </Sheet.Header>
                     <Sheet.Description>
@@ -69,15 +69,15 @@
                         
                         <!-- Mastodon -->
                         {#if userInfo.mastodonHandle}
-                            <div class={`${!$isMastodonToggled ? 'opacity-50' : 'opacity-100'} flex flex-row w-full h-full content-center bg-transparent border-2 border-mastodon rounded-md text-mastodon py-6 px-2`}>
-                                    <div class="flex flex-col ml-2 mr-4">
+                            <div class={`${!$isMastodonToggled ? 'opacity-50' : 'opacity-100'}  flex flex-row w-full h-full content-center bg-transparent border-2 py-6 px-2 border-mastodon rounded-md text-mastodon py-6 px-2`}>
+                                    <div class="flex-shrink-0 flex flex-col p-2">
                                         <img src={userInfo.mastodonPicture} alt="Mastodon Account" class="w-10 h-10 rounded-full"/>
                                     </div>
-                                    <div class="flex flex-col gap-y-0">
-                                        <span class="max-w-xs">{userInfo.mastodonDisplayName || userInfo.mastodonHandle}</span>
-                                        <span class="max-w-xs text-sm text-muted-foreground">@{userInfo.mastodonHandle}@{userInfo.mastodonInstance}</span>
+                                    <div class="flex-grow flex flex-col align-left max-w-full w-10">
+                                        <div class="max-w-xs text-ellipsis overflow-hidden">{userInfo.mastodonDisplayName || userInfo.mastodonHandle}</div>
+                                        <div class="max-w-xs text-sm text-muted-foreground text-ellipsis overflow-hidden">@{userInfo.mastodonHandle}@{userInfo.mastodonInstance}</div>
                                     </div>
-                                    <div class="flex flex-col mr-0 ml-auto mt-auto mb-auto bg-transparent text-mastodon">
+                                    <div class="flex-shrink-0 flex flex-col bg-transparent text-mastodon">
                                         <Toggle aria-label="toggle visible" on:click={toggleMastodon} class="data-[state=on]:bg-transparent data-[state=on]:text-mastodon hover:bg-transparent hover:text-mastodon">
                                             {#if !$isMastodonToggled}
                                                 <EyeClosed class="h-6 w-6" />
@@ -96,14 +96,14 @@
                         <!-- Bluesky -->
                         {#if userInfo.bskyHandle}
                             <div class={`${!$isBlueskyToggled ? 'opacity-50' : 'opacity-100'} flex flex-row w-full h-full content-center bg-transparent border-2 border-bluesky rounded-md text-bluesky py-6 px-2`}>
-                                    <div class="flex flex-col ml-2 mr-4">
+                                    <div class="flex-shrink-0 flex flex-col p-2">
                                         <img src={userInfo.bskyPicture} alt="Bluesky Account" class="w-10 h-10 rounded-full"/>
                                     </div>
-                                    <div class="flex flex-col gap-y-0">
-                                        <span class="max-w-xs">{userInfo.bskyDisplayName}</span>
-                                        <span class="max-w-xs text-sm text-muted-foreground">@{userInfo.bskyHandle}</span>
+                                    <div class="flex-grow flex flex-col align-left max-w-full w-10">
+                                        <div class="text-ellipsis overflow-hidden">{userInfo.bskyDisplayName}</div>
+                                        <div class="text-sm text-muted-foreground text-ellipsis overflow-hidden">@{userInfo.bskyHandle}</div>
                                     </div>
-                                    <div class="flex flex-col mr-0 ml-auto mt-auto mb-auto bg-transparent text-bluesky">
+                                    <div class="flex-shrink-0 flex flex-col bg-transparent text-bluesky">
                                         <Toggle aria-label="toggle visible" on:click={toggleBluesky} class="data-[state=on]:bg-transparent data-[state=on]:text-bluesky hover:bg-transparent hover:text-bluesky">
                                             {#if !($isBlueskyToggled)}
                                                 <EyeClosed class="h-6 w-6" />

--- a/src/lib/components/ui/post.svelte
+++ b/src/lib/components/ui/post.svelte
@@ -69,8 +69,8 @@
                 </div>
             {/if}
             
-            <div class="flex flex-row gap-x-10 justify-between">
-                <div class="flex flex-row justify-left gap-x-10 min-w-0">
+            <div class="flex flex-row justify-between items-center gap-8 sm:gap-16 w-auto">
+                <div class="flex flex-row justify-left min-w-0 flex-grow justify-between items-center">
                     <div class="flex flex-row items-center p-0 gap-1 font-light text-slate-500 text-sm">
                         <Comment class="h-4 w-4"/>
                         {commentCountLabel}
@@ -87,8 +87,8 @@
                     </div>
                 </div>
 
-                <a href={post.originalPostLink} target="_blank" class="flex flex-row items-center gap-1">
-                    <span class="underline text-gray-500 text-xs font-extralight line-clamp-1 italic">via</span>
+                <a href={post.originalPostLink} target="_blank" class="flex flex-row items-center gap-1 flex-shrink-0">
+                    <span class="underline text-gray-500 text-xs font-extralight line-clamp-1 italic truncate">via</span>
 
                     {#if post.platform === Platform.Mastodon}
                         <img src="/mastodon_small.svg" class="h-4 w-4" alt="Mastodon logo"/>

--- a/src/routes/timeline/+layout.svelte
+++ b/src/routes/timeline/+layout.svelte
@@ -40,7 +40,7 @@
 <main>
     <div class="min-h-screen bg-white flex justify-center">
         <!-- Main App Container -->
-        <div class="w-full max-w-[700px] bg-white border-2 border-solid border-gray-100">
+        <div class="w-full max-w-xl bg-white border-0 xl:border-2 border-solid border-gray-100">
             <Navbar userInfo={userInfo} refreshFunction={catchRefreshClick}/>
             <slot/>
         </div>

--- a/src/routes/timeline/+layout.svelte
+++ b/src/routes/timeline/+layout.svelte
@@ -38,6 +38,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <main>
-    <Navbar userInfo={userInfo} refreshFunction={catchRefreshClick}/>
-    <slot/>
+    <div class="min-h-screen bg-white flex justify-center">
+        <!-- Main App Container -->
+        <div class="w-full max-w-[700px] bg-white border-2 border-solid border-gray-100">
+            <Navbar userInfo={userInfo} refreshFunction={catchRefreshClick}/>
+            <slot/>
+        </div>
+    </div>
 </main>

--- a/src/routes/timeline/+page.svelte
+++ b/src/routes/timeline/+page.svelte
@@ -13,7 +13,8 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<div class="flex flex-col items-center justify-center w-full">
+
+<div class="flex flex-col items-center justify-center w-full min-h-screen">
     {#if (data.bskyHandle || data.mastodonUsername)}
         {#if $refreshing}
             <div class="flex flex-col items-center justify-center w-full h-screen">

--- a/src/routes/timeline/timelineData.ts
+++ b/src/routes/timeline/timelineData.ts
@@ -174,38 +174,31 @@ export const refreshTimeline = async (mastodonToken: string, mastodonInstance: s
             //handle embeds
             let embeds: PostEmbed[] = []
             let imageCount = 1
-<<<<<<< HEAD
-=======
-            if (post.post.embed){
->>>>>>> main
-            if (post.post.embed.images) {
-                for (const image of post.post.embed.images) {
+            if (post.post.embed) {
+                if (post.post.embed.images) {
+                    for (const image of post.post.embed.images) {
+                        embeds.push({
+                            href: image.fullsize,
+                            title: `Image ${imageCount}`,
+                            type: EmbedType.Image
+                        })
+                    }
+                }
+                else if (post.post.embed.thumbnail) {
                     embeds.push({
-                        href: image.fullsize,
-                        title: `Image ${imageCount}`,
-                        type: EmbedType.Image
+                        href: postURL,
+                        title: `Video`,
+                        type: EmbedType.Video
+                    })
+                }
+                else if (post.post.embed.external) {
+                    embeds.push({
+                        href: postURL,
+                        title: `External link`,
+                        type: EmbedType.Link
                     })
                 }
             }
-            else if (post.post.embed.thumbnail) {
-                embeds.push({
-                    href: postURL,
-                    title: `Video`,
-                    type: EmbedType.Video
-                })
-            }
-            else if (post.post.embed.external) {
-                embeds.push({
-                    href: postURL,
-                    title: `External link`,
-                    type: EmbedType.Link
-                })
-<<<<<<< HEAD
-            }
-=======
-            }}
->>>>>>> main
-
 
             bskyTimeline.push({
                 platform: Platform.Bluesky,


### PR DESCRIPTION
Solves #29 and #30 

Sidebar & posts now dynamically resize. Clamped the main timeline div to `xl` screen size like Twitter. Screenshots below.

**Clamped screen size**
<img width="1418" alt="Screenshot 2024-11-17 at 10 27 20 AM" src="https://github.com/user-attachments/assets/bb74a2f4-cfd2-4b43-a22c-3a40ace995c2">
<img width="1411" alt="Screenshot 2024-11-17 at 10 27 32 AM" src="https://github.com/user-attachments/assets/1bd9f16c-f4f9-47a7-a1a3-b8dfee032b28">

**Sidebar bugs fixed**
<img width="359" alt="Screenshot 2024-11-17 at 10 28 14 AM" src="https://github.com/user-attachments/assets/7c5666af-c8bd-427e-8d40-e5ba31d30cb4">
