### PR TITLE
Fix/bsky token refresh

### DIFF
--- a/src/lib/bluesky.ts
+++ b/src/lib/bluesky.ts
@@ -1,0 +1,44 @@
+async function isBskyTokenActive(token: string): Promise<Boolean> {
+    return await fetch('https://bsky.social/xrpc/com.atproto.server.getSession', {
+        headers: {
+            "Authorization": `Bearer ${token}`
+        }
+    }).then(res => res.json())
+    .then(res => {
+        if (res.active)
+            return true
+        else if (res.error == "ExpiredToken")
+            return false
+        else
+            throw new Error(res.error);
+    })
+}
+
+export async function refreshBskyToken(token: string, refreshToken: string){
+    try {
+        const isActive = await isBskyTokenActive(token)
+
+        if (isActive)
+            return { status: "active" }
+        else {
+            // refresh tokens
+            const res = await fetch('https://bsky.social/xrpc/com.atproto.server.refreshSession', {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${refreshToken}`
+                }
+            })
+            const newTokens = await res.json()
+
+            if (newTokens.error)
+                throw new Error(newTokens.error)
+
+            console.log(newTokens)
+            console.log(`new tokens: ${newTokens.accessJwt} ${newTokens.refreshJwt}`)
+            return { status: "refreshed", token: newTokens.accessJwt, refreshToken: newTokens.refreshJwt }
+        }
+    } catch (e){
+        console.error(e)
+        return { status: "failed"}
+    }
+}

--- a/src/routes/connect/+page.server.ts
+++ b/src/routes/connect/+page.server.ts
@@ -2,7 +2,7 @@ import { SITE_URI, SECURE } from '$env/static/private';
 import { error, fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = ({locals, cookies}) => {
+export const load: PageServerLoad = ({ locals, cookies }) => {
     // const mastodonAccess = new FormData();
     // mastodonAccess.append("client_id", MASTODON_CLIENT_ID)
     // mastodonAccess.append("client_secret", MASTODON_CLIENT_SECRET)
@@ -31,11 +31,11 @@ export const load: PageServerLoad = ({locals, cookies}) => {
 
 /** @type {import('./$types').Actions} */
 export const actions = {
-    mastodon: async ({ request, cookies}) => {
+    mastodon: async ({ request, cookies }) => {
         const formData = await request.formData();
         const instance = String(formData.get('instance'))
-        let failure : null | string = null
-        let redirecturl : null | string = null
+        let failure: null | string = null
+        let redirecturl: null | string = null
         console.error(`instance: ${instance}`)
 
         //register app to instance
@@ -47,33 +47,33 @@ export const actions = {
         appRegisterData.append("website", "https://timeline-viewer-seven.vercel.app")
 
 
-        await fetch(`https://${instance}/api/v1/apps`, 
-        {
-            method: "POST",
-            body: appRegisterData
-        }).then(res => {
-            if (!res.ok) {
-                throw new Error("Either instance URL is invalid or instance is currently down.")
-            }
+        await fetch(`https://${instance}/api/v1/apps`,
+            {
+                method: "POST",
+                body: appRegisterData
+            }).then(res => {
+                if (!res.ok) {
+                    throw new Error("Either instance URL is invalid or instance is currently down.")
+                }
 
-            return res.json()
-        }).then(res => {
-            //now have client id and client secret, 
-            console.log(res)
-            const id = res.client_id
-            const secret = res.client_secret
-            redirecturl = `https://${instance}/oauth/authorize?` + new URLSearchParams({
-                client_id: id,
-                response_type: "code",
-                redirect_uri: SITE_URI
-            }).toString()
+                return res.json()
+            }).then(res => {
+                //now have client id and client secret, 
+                console.log(res)
+                const id = res.client_id
+                const secret = res.client_secret
+                redirecturl = `https://${instance}/oauth/authorize?` + new URLSearchParams({
+                    client_id: id,
+                    response_type: "code",
+                    redirect_uri: SITE_URI
+                }).toString()
 
-            cookies.set("mastodonClientId", id, { path: "/", ...(SECURE === "FALSE" && {secure: false}) })
-            cookies.set("mastodonClientSecret", secret, { path: "/", ...(SECURE === "FALSE" && {secure: false}) })
-            cookies.set("mastodonInstance", instance, { path: "/", ...(SECURE === "FALSE" && {secure: false}) })
-        }).catch(error => {
-            failure = error.message
-        })
+                cookies.set("mastodonClientId", id, { path: "/", ...(SECURE === "FALSE" && { secure: false }) })
+                cookies.set("mastodonClientSecret", secret, { path: "/", ...(SECURE === "FALSE" && { secure: false }) })
+                cookies.set("mastodonInstance", instance, { path: "/", ...(SECURE === "FALSE" && { secure: false }) })
+            }).catch(error => {
+                failure = error.message
+            })
 
         if (failure)
             return fail(400, {
@@ -93,7 +93,7 @@ export const actions = {
                 }
             })
     },
-	bluesky: async ({ request, cookies }) => {
+    bluesky: async ({ request, cookies }) => {
         const formData = await request.formData();
         const handle = String(formData.get('handle'))
 
@@ -107,10 +107,10 @@ export const actions = {
                     message: profile.message
                 }
             })
-        
+
         const bskyAccess = {
-            "identifier": profile.did, 
-			"password": String(formData.get('password')), 
+            "identifier": profile.did,
+            "password": String(formData.get('password')),
         }
 
         // request access token
@@ -123,10 +123,11 @@ export const actions = {
         })
             .then(res => res.json())
             .then(res => {
+                // console.log(res)
                 if (res.did) { //set if correct
-                    cookies.set("bskyToken", res.accessJwt, { path: "/", ...(SECURE === "FALSE" && {secure: false}) })
-                    cookies.set("bskyRefreshToken", res.refreshJwt, { path: "/", ...(SECURE === "FALSE" && {secure: false}) })
-                    cookies.set("bskyDid", res.did, { path: "/", ...(SECURE === "FALSE" && {secure: false}) })
+                    cookies.set("bskyToken", res.accessJwt, { path: "/", httpOnly: true, maxAge: 172800, ...(SECURE === "FALSE" && { secure: false }) })
+                    cookies.set("bskyRefreshToken", res.refreshJwt, { path: "/", httpOnly: true, maxAge: 172800, ...(SECURE === "FALSE" && { secure: false }) })
+                    cookies.set("bskyDid", res.did, { path: "/", httpOnly: true, maxAge: 604800, ...(SECURE === "FALSE" && { secure: false }) })
                 } else if (res.error)
                     return fail(401, {
                         error: {
@@ -142,7 +143,7 @@ export const actions = {
                 })
             })
             .catch(error => {
-            //do something
+                //do something
                 return fail(401, {
                     error: {
                         platform: "bluesky",
@@ -150,6 +151,6 @@ export const actions = {
                     }
                 })
             })
-		
-	}
+
+    }
 } satisfies Actions;

--- a/src/routes/timeline/+page.server.ts
+++ b/src/routes/timeline/+page.server.ts
@@ -1,7 +1,19 @@
 import type { PageServerLoad } from "../$types";
 import { refreshTimeline } from "./timelineData";
+import { refreshBskyToken } from '$lib/bluesky'
 
 export const load: PageServerLoad = async ({ cookies }) => {
+    // check and refresh bsky token before requesting data
+    if (cookies.get("bskyToken") && cookies.get("bskyDid")) {
+        const bskyTokens = await refreshBskyToken(cookies.get("bskyToken"), cookies.get("bskyRefreshToken"))
+        if (bskyTokens.status === "refreshed"){
+            cookies.set("bskyToken", bskyTokens.token, { path: "/", httpOnly: true, secure: true, maxAge: 172800 })
+            cookies.set("bskyRefreshToken", bskyTokens.refreshToken, { path: "/", httpOnly: true, secure: true, maxAge: 172800 })
+        } 
+
+        console.log(`token status: ${bskyTokens.status}`)
+    }
+
     return {
         timelineData: await refreshTimeline(cookies.get("mastodonToken"), cookies.get("mastodonInstance"), cookies.get("bskyToken"))
     }


### PR DESCRIPTION
Features:
- new $lib module bluesky.ts with 2 functions: isBskyTokenActive() and refreshBskyToken()
- extend bluesky cookie lifespan (did, tokens) on login
- set access token cookies as httponly and secure
- checks token expiry on pages '/' and '/timeline' + refreshes token if expired
- resolves #8 